### PR TITLE
Change auth/token endpoint name for auth/log_in and return user info

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,9 +1,9 @@
 from django.urls import path
-from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
-from .views import registration
+from rest_framework_simplejwt.views import TokenRefreshView
+from .views import registration, log_in
 
 urlpatterns = [
     path('register/', registration, name='register'),
-    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('log_in/', log_in, name='log_in'),
     path('refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,4 +1,4 @@
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, authenticate
 from rest_framework import permissions, response, decorators, status
 from rest_framework_simplejwt.tokens import RefreshToken
 from .serializers import UserCreateSerializer
@@ -11,7 +11,8 @@ User = get_user_model()
 def registration(request):
     serializer = UserCreateSerializer(data=request.data)
     if not serializer.is_valid():
-        return response.Response(serializer.errors, status.HTTP_400_BAD_REQUEST)
+        return response.Response(serializer.errors,
+                                 status.HTTP_400_BAD_REQUEST)
     user = serializer.save()
     refresh = RefreshToken.for_user(user)
     res = {
@@ -19,3 +20,20 @@ def registration(request):
         "access": str(refresh.access_token),
     }
     return response.Response(res, status.HTTP_201_CREATED)
+
+
+@decorators.api_view(["POST"])
+@decorators.permission_classes([permissions.AllowAny])
+def log_in(request):
+    username, password = request.data['username'], request.data['password']
+    user = authenticate(username=username, password=password)
+    if user is not None:
+        refresh = RefreshToken.for_user(user)
+        res = {
+            "refresh": str(refresh),
+            "access": str(refresh.access_token),
+            "username": username,
+            "email": user.email
+        }
+        return response.Response(res, status.HTTP_200_OK)
+    return response.Response(status.HTTP_401_UNAUTHORIZED)


### PR DESCRIPTION
- Se cambió el nombre del _endpoint_ `auth/token` por `auth/log_in`
- Se añadieron los campos _username_ y _email_ a la respuesta del endpoint `auth/log_in`